### PR TITLE
Set found to false if any paths are not found

### DIFF
--- a/lib/rubygems/commands/which_command.rb
+++ b/lib/rubygems/commands/which_command.rb
@@ -56,9 +56,10 @@ requiring to see why it does not behave as you expect.
 
       if paths.empty? then
         alert_error "Can't find ruby library file or shared library #{arg}"
+        found = false
       else
         say paths
-        found = true
+        found ||= true
       end
     end
 


### PR DESCRIPTION
Many unix utilities exit with a code of 1 if any parts of the command fail, in particular `rpm`.  I believe its desirable for gem to behave similar to `rpm -q` for this use case.

rpm case

```
# rpm -q man
man-1.6f-32.el6.x86_64
# echo $?
0
```

```
# rpm -q man cheese
man-1.6f-32.el6.x86_64
package cheese is not installed
# echo $?
1
```

gem which case

```
$ gem which capistrano
/opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-2.15.5/lib/capistrano.rb
evilensky@Vilensky~/src/puppet/lib/puppet (add-yum-uninstall-to-yum-provider)$ echo $?
0
```

```
$ gem which capistrano rails
/opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/gems/1.9.1/gems/capistrano-2.15.5/lib/capistrano.rb
ERROR:  Can't find ruby library file or shared library rails
$ echo $?
0
```
